### PR TITLE
Byte 175: Versionamento do banco

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,12 +47,12 @@ jobs:
 
       - name: Criar usuário e permissões no MySQL
         run: |
-          mysql_prod -h 172.18.0.1 -P 3306 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
-          mysql_prod -h 172.18.0.1 -P 3306 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON dataviz_bytelabss.* TO 'userapp'@'172.18.0.1';"
-          mysql_prod -h 172.18.0.1 -P 3306 -u root -proot -e "FLUSH PRIVILEGES;"
-          mysql_test -h 172.18.0.1 -P 3307 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
-          mysql_test -h 172.18.0.1 -P 3307 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON test_db.* TO 'userapp'@'172.18.0.1';"
-          mysql_test -h 172.18.0.1 -P 3307 -u root -proot -e "FLUSH PRIVILEGES;"
+          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
+          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON dataviz_bytelabss.* TO 'userapp'@'172.18.0.1';"
+          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "FLUSH PRIVILEGES;"
+          mysql -h 172.18.0.1 -P 3307 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
+          mysql -h 172.18.0.1 -P 3307 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON test_db.* TO 'userapp'@'172.18.0.1';"
+          mysql -h 172.18.0.1 -P 3307 -u root -proot -e "FLUSH PRIVILEGES;"
 
       - name: Compilar com Maven
         run: mvn clean install --no-transfer-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,3 +73,7 @@ jobs:
       - name: Executar testes de integração (somente em PR para dev e main)
         if: github.event_name == 'pull_request' && (github.base_ref == 'dev' || github.base_ref == 'main')
         run: mvn verify -P integration-tests -DskipUnitTests=false --no-transfer-progress
+      
+      - name: Executar migrações Flyway
+        run: mvn flyway:migrate -Dflyway.debug=true
+      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           mysql -h 172.18.0.1 -P 3306 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
           mysql -h 172.18.0.1 -P 3306 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON dataviz_bytelabss.* TO 'userapp'@'172.18.0.1';"
+          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON test_db.* TO 'userapp'@'172.18.0.1';"
           mysql -h 172.18.0.1 -P 3306 -u root -proot -e "FLUSH PRIVILEGES;"
 
       - name: Compilar com Maven

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,3 @@ jobs:
         if: github.event_name == 'pull_request' && (github.base_ref == 'dev' || github.base_ref == 'main')
         run: mvn verify -P integration-tests -DskipUnitTests=false --no-transfer-progress
       
-      - name: Executar migrações Flyway
-        run: mvn flyway:migrate -Dflyway.debug=true
-      

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,13 +14,22 @@ jobs:
     runs-on: ubuntu-latest
 
     services:
-      mysql:
+      mysql_prod:
         image: mysql:5.7
         env:
           MYSQL_DATABASE: dataviz_bytelabss
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      mysql_test:
+        image: mysql:5.7
+        env:
+          MYSQL_DATABASE: test_db
+          MYSQL_ROOT_PASSWORD: root
+        ports:
+          - 3307:3306
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
@@ -38,10 +47,12 @@ jobs:
 
       - name: Criar usuário e permissões no MySQL
         run: |
-          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
-          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON dataviz_bytelabss.* TO 'userapp'@'172.18.0.1';"
-          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON test_db.* TO 'userapp'@'172.18.0.1';"
-          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "FLUSH PRIVILEGES;"
+          mysql_prod -h 172.18.0.1 -P 3306 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
+          mysql_prod -h 172.18.0.1 -P 3306 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON dataviz_bytelabss.* TO 'userapp'@'172.18.0.1';"
+          mysql_prod -h 172.18.0.1 -P 3306 -u root -proot -e "FLUSH PRIVILEGES;"
+          mysql_test -h 172.18.0.1 -P 3307 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
+          mysql_test -h 172.18.0.1 -P 3307 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON test_db.* TO 'userapp'@'172.18.0.1';"
+          mysql_test -h 172.18.0.1 -P 3307 -u root -proot -e "FLUSH PRIVILEGES;"
 
       - name: Compilar com Maven
         run: mvn clean install --no-transfer-progress

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,11 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3306:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
       mysql_test:
         image: mysql:5.7
@@ -30,7 +34,11 @@ jobs:
           MYSQL_ROOT_PASSWORD: root
         ports:
           - 3307:3306
-        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+        options: >-
+          --health-cmd="mysqladmin ping -h localhost --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
 
     steps:
       - name: Checkout do código
@@ -45,23 +53,23 @@ jobs:
           java-version: '17'
           cache: maven        
 
-      - name: Criar usuário e permissões no MySQL
+      - name: Criar usuários e permissões no MySQL
         run: |
-          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
-          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON dataviz_bytelabss.* TO 'userapp'@'172.18.0.1';"
-          mysql -h 172.18.0.1 -P 3306 -u root -proot -e "FLUSH PRIVILEGES;"
-          mysql -h 172.18.0.1 -P 3307 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'172.18.0.1' IDENTIFIED BY 'admin123';"
-          mysql -h 172.18.0.1 -P 3307 -u root -proot -e "GRANT SELECT, INSERT, CREATE, REFERENCES, UPDATE, DELETE, DROP ON test_db.* TO 'userapp'@'172.18.0.1';"
-          mysql -h 172.18.0.1 -P 3307 -u root -proot -e "FLUSH PRIVILEGES;"
+          sleep 20 # Aguarda os serviços do MySQL estarem prontos
+          echo "Configurando permissões no MySQL de produção"
+          mysql -h 127.0.0.1 -P 3306 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'%' IDENTIFIED BY 'admin123';"
+          mysql -h 127.0.0.1 -P 3306 -u root -proot -e "GRANT ALL PRIVILEGES ON dataviz_bytelabss.* TO 'userapp'@'%'; FLUSH PRIVILEGES;"
+
+          echo "Configurando permissões no MySQL de testes"
+          mysql -h 127.0.0.1 -P 3307 -u root -proot -e "CREATE USER IF NOT EXISTS 'userapp'@'%' IDENTIFIED BY 'admin123';"
+          mysql -h 127.0.0.1 -P 3307 -u root -proot -e "GRANT ALL PRIVILEGES ON test_db.* TO 'userapp'@'%'; FLUSH PRIVILEGES;"
 
       - name: Compilar com Maven
         run: mvn clean install --no-transfer-progress
 
-      # Executar testes unitários em todos os commits de todas as branches
       - name: Executar testes unitários
         run: mvn test --no-transfer-progress
 
-      # Executar testes de integração apenas em pull requests para 'dev' e 'main'
       - name: Executar testes de integração (somente em PR para dev e main)
         if: github.event_name == 'pull_request' && (github.base_ref == 'dev' || github.base_ref == 'main')
         run: mvn verify -P integration-tests -DskipUnitTests=false --no-transfer-progress

--- a/pom.xml
+++ b/pom.xml
@@ -210,7 +210,7 @@
             <id>test</id>
             <properties>
                 <spring.profiles.active>test</spring.profiles.active>
-                <flyway.url>jdbc:mysql://localhost:3306/test_db</flyway.url>
+                <flyway.url>jdbc:mysql://localhost:3307/test_db</flyway.url>
                 <flyway.user>userapp</flyway.user>
                 <flyway.password>admin123</flyway.password>
                 <flyway.locations>classpath:/db/migration/migrations,classpath:/db/migration/migrations/commons</flyway.locations>
@@ -220,7 +220,7 @@
             <id>integration-tests</id>
             <properties>
                 <!-- Propriedades do Flyway para o banco de teste -->
-                <flyway.url>jdbc:mysql://localhost:3306/test_db</flyway.url>
+                <flyway.url>jdbc:mysql://localhost:3307/test_db</flyway.url>
                 <flyway.user>userapp</flyway.user>
                 <flyway.password>admin123</flyway.password>
                 <flyway.locations>classpath:/db/migration/migrations,classpath:/db/migration/migrations/commons</flyway.locations>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
-                    <jvmArguments>--add-opens java.base/sun.nio.ch=ALL-UNNAMED</jvmArguments>
+                    <jvmArguments>--add-opens java.base/sun.nio.ch=ALL-UNNAMED -Dspring.profiles.active=${spring.profiles.active}</jvmArguments>
                 </configuration>
             </plugin>
 
@@ -194,7 +194,7 @@
         <profile>
             <id>production</id>
             <properties>
-                <spring.profiles.active>test</spring.profiles.active>
+                <spring.profiles.active>production</spring.profiles.active>
                 <flyway.url>jdbc:mysql://localhost:3306/dataviz_bytelabss</flyway.url>
                 <flyway.user>userapp</flyway.user>
                 <flyway.password>admin123</flyway.password>

--- a/pom.xml
+++ b/pom.xml
@@ -168,9 +168,9 @@
                 <artifactId>flyway-maven-plugin</artifactId>
                 <version>10.20.1</version>
                 <configuration>
-                    <url>jdbc:mysql://localhost:3306/dataviz_bytelabss</url>
-                    <user>userapp</user>
-                    <password>admin123</password>
+                    <url>${flyway.url}</url>
+                    <user>${flyway.user}</user>
+                    <password>${flyway.password}</password>
                     <locations>
                         <location>classpath:/db/migration/migrations</location>
                     </locations>
@@ -191,21 +191,74 @@
         </plugins>
     </build>
     <profiles>
-    <profile>
-        <id>integration-tests</id>
-        <build>
-            <plugins>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <configuration>
-                        <includes>
-                            <include>**/*IntegrationTest.java</include>
-                        </includes>
-                    </configuration>
-                </plugin>
-            </plugins>
-        </build>
-    </profile>
-</profiles>
+        <profile>
+            <id>production</id>
+            <properties>
+                <spring.profiles.active>test</spring.profiles.active>
+                <flyway.url>jdbc:mysql://localhost:3306/dataviz_bytelabss</flyway.url>
+                <flyway.user>userapp</flyway.user>
+                <flyway.password>admin123</flyway.password>
+                <flyway.locations>classpath:/db/migration/migrations/commons</flyway.locations>
+            </properties>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+        </profile>
+
+        <!-- Perfil de teste -->
+        <profile>
+            <id>test</id>
+            <properties>
+                <spring.profiles.active>test</spring.profiles.active>
+                <flyway.url>jdbc:mysql://localhost:3306/test_db</flyway.url>
+                <flyway.user>userapp</flyway.user>
+                <flyway.password>admin123</flyway.password>
+                <flyway.locations>classpath:/db/migration/migrations,classpath:/db/migration/migrations/commons</flyway.locations>
+            </properties>
+        </profile>
+        <profile>
+            <id>integration-tests</id>
+            <properties>
+                <!-- Propriedades do Flyway para o banco de teste -->
+                <flyway.url>jdbc:mysql://localhost:3306/test_db</flyway.url>
+                <flyway.user>userapp</flyway.user>
+                <flyway.password>admin123</flyway.password>
+                <flyway.locations>classpath:/db/migration/migrations,classpath:/db/migration/migrations/commons</flyway.locations>
+            </properties>
+            <build>
+                <plugins>
+                    <!-- Configuração do Surefire para testes de integração -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <includes>
+                                <include>**/*IntegrationTest.java</include>
+                            </includes>
+                        </configuration>
+                    </plugin>
+
+                    <!-- Flyway para preparar o banco antes dos testes -->
+                    <plugin>
+                        <groupId>org.flywaydb</groupId>
+                        <artifactId>flyway-maven-plugin</artifactId>
+                        <configuration>
+                            <url>${flyway.url}</url>
+                            <user>${flyway.user}</user>
+                            <password>${flyway.password}</password>
+                            <locations>${flyway.locations}</locations>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <phase>pre-integration-test</phase>
+                                <goals>
+                                    <goal>migrate</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/resources/application-production.properties
+++ b/src/main/resources/application-production.properties
@@ -1,0 +1,5 @@
+spring.flyway.url=jdbc:mysql://localhost:3306/dataviz_bytelabss
+spring.flyway.user=userapp
+spring.flyway.password=admin123
+spring.flyway.locations=classpath:/db/migration/migrations/commons
+

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -7,4 +7,4 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.flyway.url=jdbc:mysql://localhost:3307/test_db
 spring.flyway.user=userapp
 spring.flyway.password=admin123
-spring.flyway.locations=classpath:/db/migration/migrations,classpath:/db/migration/migrations/commons
+spring.flyway.locations=classpath:/db/migration/migrations

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,0 +1,10 @@
+spring.datasource.url=jdbc:mysql://localhost:3306/test_db
+spring.datasource.username=userapp
+spring.datasource.password=admin123
+spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
+
+spring.flyway.url=jdbc:mysql://localhost:3306/test_db
+spring.flyway.user=userapp
+spring.flyway.password=admin123
+spring.flyway.locations=classpath:/db/migration/migrations,classpath:/db/migration/migrations/commons

--- a/src/main/resources/application-test.properties
+++ b/src/main/resources/application-test.properties
@@ -1,10 +1,10 @@
-spring.datasource.url=jdbc:mysql://localhost:3306/test_db
+spring.datasource.url=jdbc:mysql://localhost:3307/test_db
 spring.datasource.username=userapp
 spring.datasource.password=admin123
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
 spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 
-spring.flyway.url=jdbc:mysql://localhost:3306/test_db
+spring.flyway.url=jdbc:mysql://localhost:3307/test_db
 spring.flyway.user=userapp
 spring.flyway.password=admin123
 spring.flyway.locations=classpath:/db/migration/migrations,classpath:/db/migration/migrations/commons

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,3 +8,5 @@ spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQLDialect
 spring.jpa.properties.hibernate.boot.allow_jdbc_metadata_access=false
 
 server.port=9090
+
+spring.profiles.active=production


### PR DESCRIPTION
Este PR está adicionando a possibilidade de o Flyway apontar para o banco de teste dependendo da situação.

Adicionei o banco `test_db` para fazer os testes. Para rodar, é só usar:

- `mvn spring-boot:run -Ptest`: para rodar o perfil de testes
- `mvn spring-boot:run -Pproduction`: para rodar o perfil de produção explicitamente
- `mvn spring-boot:run`: para rodar o perfil de prod também (deixei esse como default)

Para os comandos do Flyway, mesma coisa:

- `mvn flyway:info -Ptest`: para rodar apontando para o banco de teste
- `mvn flyway:repair -Ptest`: para rodar apontando para o banco de produção